### PR TITLE
Update magic_shell dependency to >= 1.0.0

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,4 +5,4 @@ license          'Apache 2.0'
 description      'Installs/Configures aliases'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.1'
-depends          'magic_shell', '~> 0.2.0'
+depends          'magic_shell', '>= 1.0.0'


### PR DESCRIPTION
This is needed to update the magic_shell cookbook to fix path issues on seagrant-prod/seagrant-staging.